### PR TITLE
fix: Fix missing Windows package dependency

### DIFF
--- a/shaka-lab-node/windows/shaka-lab-node.nuspec
+++ b/shaka-lab-node/windows/shaka-lab-node.nuspec
@@ -38,6 +38,7 @@
 
     <dependencies>
       <dependency id="nodejs" version="12.0" />
+      <dependency id="openjdk.portable" version="11.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
We depend on Java to run Selenium, but did not have an explicit dependency on it before.