### PR TITLE
fix: Fix Linux deployment errors

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install deps
         run: |
+          sudo apt -y update
           sudo apt -y install \
               coreutils debhelper devscripts fakeroot gpg reprepro
 


### PR DESCRIPTION
Update Ubuntu package lists before installing missing deps, to avoid 404 errors.