### PR TITLE
fix(mac): Fix Homebrew path on Intel macs

### DIFF
--- a/shaka-lab-node/macos/README.md
+++ b/shaka-lab-node/macos/README.md
@@ -17,36 +17,37 @@ platforms, see [the general docs](../README.md#readme).
 ```sh
 brew tap shaka-project/shaka-lab
 brew install shaka-lab-node
-/opt/homebrew/opt/shaka-lab-node/restart-services.sh
+$(brew --prefix)/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Updates
 
 ```sh
 brew update && brew upgrade
-/opt/homebrew/opt/shaka-lab-node/restart-services.sh
+$(brew --prefix)/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Configuration
 
-The config file is at `/opt/homebrew/etc/shaka-lab-node-config.yaml`.
+The config file is at `/opt/homebrew/etc/shaka-lab-node-config.yaml` on Arm and
+`/usr/local/etc/shaka-lab-node-config.yaml` on Intel.
 See the [configuration section](../README.md#configuration) of the general doc.
 
 ## Restarting the service after editing the config
 
 ```sh
-/opt/homebrew/opt/shaka-lab-node/restart-services.sh
+$(brew --prefix)/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Tailing logs
 
 ```sh
-tail -f /opt/homebrew/var/log/shaka-lab-node.err.log
+tail -f $(brew --prefix)/var/log/shaka-lab-node.err.log
 ```
 
 ## Uninstallation
 
 ```sh
-/opt/homebrew/opt/shaka-lab-node/stop-services.sh
+$(brew --prefix)/opt/shaka-lab-node/stop-services.sh
 brew uninstall shaka-lab-node
 ```

--- a/shaka-lab-node/macos/restart-services.sh
+++ b/shaka-lab-node/macos/restart-services.sh
@@ -45,7 +45,7 @@ restart_service shaka-lab-node-service
 if [ ! -f /etc/newsyslog.d/shaka-lab-node.conf ]; then
   echo "Configuring service log rotation (using sudo)"
   sudo tee /etc/newsyslog.d/shaka-lab-node.conf >/dev/null <<EOF
-# path                                     mode  count  size  when  flags pid_file
-/opt/homebrew/var/log/shaka-lab-node.*.log 644   10     10240 *     Z     /opt/homebrew/var/run/shaka-lab-node.pid
+# path                                        mode  count  size  when  flags pid_file
+$(brew --prefix)/var/log/shaka-lab-node.*.log 644   10     10240 *     Z     $(brew --prefix)/var/run/shaka-lab-node.pid
 EOF
 fi

--- a/shaka-lab-node/macos/shaka-lab-node-service.plist
+++ b/shaka-lab-node/macos/shaka-lab-node-service.plist
@@ -25,18 +25,18 @@
     <key>ProgramArguments</key>
     <array>
       <!-- The log wrapper works around issues with log rotation / launchd. -->
-      <string>/opt/homebrew/bin/node</string>
-      <string>/opt/homebrew/opt/shaka-lab-node/log-wrapper.js</string>
-      <string>/opt/homebrew/var/log/shaka-lab-node.out.log</string>
-      <string>/opt/homebrew/var/log/shaka-lab-node.err.log</string>
-      <string>/opt/homebrew/var/run/shaka-lab-node.pid</string>
+      <string>$HOMEBREW_PREFIX/bin/node</string>
+      <string>$HOMEBREW_PREFIX/opt/shaka-lab-node/log-wrapper.js</string>
+      <string>$HOMEBREW_PREFIX/var/log/shaka-lab-node.out.log</string>
+      <string>$HOMEBREW_PREFIX/var/log/shaka-lab-node.err.log</string>
+      <string>$HOMEBREW_PREFIX/var/run/shaka-lab-node.pid</string>
       <!-- This is the service started by the wrapper. -->
-      <string>/opt/homebrew/bin/node</string>
-      <string>/opt/homebrew/opt/shaka-lab-node/start-nodes.js</string>
+      <string>$HOMEBREW_PREFIX/bin/node</string>
+      <string>$HOMEBREW_PREFIX/opt/shaka-lab-node/start-nodes.js</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/opt/homebrew/opt/shaka-lab-node</string>
+    <string>$HOMEBREW_PREFIX/opt/shaka-lab-node</string>
 
     <key>RunAtLoad</key>
     <true/>

--- a/shaka-lab-node/macos/shaka-lab-node-update.plist
+++ b/shaka-lab-node/macos/shaka-lab-node-update.plist
@@ -24,7 +24,7 @@
 
     <key>ProgramArguments</key>
     <array>
-      <string>/opt/homebrew/opt/shaka-lab-node/update-drivers.sh</string>
+      <string>$HOMEBREW_PREFIX/opt/shaka-lab-node/update-drivers.sh</string>
     </array>
 
     <key>RunAtLoad</key>

--- a/shaka-lab-node/macos/shaka-lab-node.rb
+++ b/shaka-lab-node/macos/shaka-lab-node.rb
@@ -82,6 +82,12 @@ class ShakaLabNode < Formula
     FileUtils.install "#{source_root}/shaka-lab-node/macos/stop-services.sh", prefix, :mode => 0755
     FileUtils.install "#{source_root}/shaka-lab-node/macos/restart-services.sh", prefix, :mode => 0755
 
+    # The service definitions need hard-coded paths, and the Homebrew prefix
+    # varies.  So replace "$HOMEBREW_PREFIX" in these plist files with the
+    # current prefix (in the HOMEBREW_PREFIX variable).
+    inreplace prefix/"shaka-lab-node-service.plist", "$HOMEBREW_PREFIX", HOMEBREW_PREFIX
+    inreplace prefix/"shaka-lab-node-update.plist", "$HOMEBREW_PREFIX", HOMEBREW_PREFIX
+
     # Service logs go to /opt/homebrew/var/log
     FileUtils.mkdir_p var/"log"
 

--- a/shaka-lab-node/macos/update-drivers.sh
+++ b/shaka-lab-node/macos/update-drivers.sh
@@ -21,7 +21,7 @@
 set -e
 
 # Load Homebrew.
-eval "$(/opt/homebrew/bin/brew shellenv)"
+eval "$(brew shellenv)"
 
 # Go to the install directory of shaka-lab-node.
 cd "$(brew --prefix shaka-lab-node)"

--- a/shaka-lab-node/shaka-lab-node-config.md
+++ b/shaka-lab-node/shaka-lab-node-config.md
@@ -5,7 +5,8 @@ in a different location per platform:
 
  - Linux: `/etc/shaka-lab-node-config.yaml`
  - Windows: `c:\ProgramData\shaka-lab-node\node-config.yaml`
- - macOS: `/opt/homebrew/etc/shaka-lab-node-config.yaml`
+ - macOS (Arm): `/opt/homebrew/etc/shaka-lab-node-config.yaml`
+ - macOS (Intel): `/usr/local/etc/shaka-lab-node-config.yaml`
 
 A default config is provided on installation, which contains only Chrome, but
 has commented sections for every supported browser.  For the latest version of

--- a/shaka-lab-node/start-nodes.js
+++ b/shaka-lab-node/start-nodes.js
@@ -40,9 +40,18 @@ if (process.platform == 'win32') {
   exe = '.exe';
   cmd = '.cmd';
 } else if (process.platform == 'darwin') {
-  configPath = '/opt/homebrew/etc/shaka-lab-node-config.yaml';
-  shakaLabNodePath = '/opt/homebrew/opt/shaka-lab-node';
-  workingDirectory = '/opt/homebrew/opt/shaka-lab-node';
+  // Homebrew can be installed at an arbitrary location, and even the default
+  // varies by processor type.  (/opt/homebrew for Arm and /usr/local for
+  // Intel.)
+  const prefixProcess = child_process.spawnSync('brew', ['--prefix'], {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    encoding: 'utf8',
+  });
+  const prefix = prefixProcess.stdout.trim();
+
+  configPath = `${prefix}/etc/shaka-lab-node-config.yaml`;
+  shakaLabNodePath = `${prefix}/opt/shaka-lab-node`;
+  workingDirectory = `${prefix}/opt/shaka-lab-node`;
   updateDrivers = `${shakaLabNodePath}/update-drivers.sh`;
 }
 


### PR DESCRIPTION
Homebrew can be installed at an arbitrary location, and even the default varies by processor type.  (/opt/homebrew for Arm and /usr/local for Intel.)

This fixes the hard-coded paths in the code and docs.  The shaka-lab-node package now works on both Arm and Intel macs.