### PR TITLE
ci: Fix hard-coded parameters in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,8 +180,8 @@ jobs:
         with:
           # TODO: For now, this is the only project we can deploy to, due to
           # internal Google Cloud Platform restrictions.
-          project_id: shaka-player-demo
-          version: shaka-lab-chocolatey
+          project_id: '${{ secrets.APPENGINE_PROJECT_ID }}'
+          version: '${{ secrets.APPENGINE_PROJECT_VERSION }}'
           promote: false
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,8 +178,6 @@ jobs:
 
       - uses: google-github-actions/deploy-appengine@v0
         with:
-          # TODO: For now, this is the only project we can deploy to, due to
-          # internal Google Cloud Platform restrictions.
           project_id: '${{ secrets.APPENGINE_PROJECT_ID }}'
           version: '${{ secrets.APPENGINE_PROJECT_VERSION }}'
           promote: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -194,7 +194,7 @@ jobs:
       - name: Check out tap repo
         uses: actions/checkout@v3
         with:
-          repository: shaka-project/homebrew-shaka-lab
+          repository: '${{ secrets.HOMEBREW_TAP_REPO }}'
           fetch-depth: 0  # The entire repo history, so we can push an update
 
       - name: Wipe source and formula folders
@@ -240,4 +240,4 @@ jobs:
           # environment, since we're pushing to a different repo as a different
           # user.
           git config --unset-all http.https://github.com/.extraheader
-          git push https://shaka-bot:${{ secrets.HOMEBREW_DEPLOY_TOKEN }}@github.com/shaka-project/homebrew-shaka-lab
+          git push https://shaka-bot:${{ secrets.HOMEBREW_DEPLOY_TOKEN }}@github.com/${{ secrets.HOMEBREW_TAP_REPO }}

--- a/distribution/macos/README.md
+++ b/distribution/macos/README.md
@@ -16,10 +16,13 @@ update notifications from Homebrew for their macOS packages.
 1. Create a tap repo (`homebrew-shaka-lab`).
 2. Create a GitHub Personal Access Token (PAT) for a user authorized on the
    `homebrew-shaka-lab` repo.  For example, we are using
-   [`shaka-bot`](https://github.com/shaka-bot)
+   [`shaka-bot`](https://github.com/shaka-bot).  The access token must have the
+   `repo` scope enabled.
 3. Copy the PAT into GitHub as a secret on this repository named
    `HOMEBREW_DEPLOY_TOKEN`.
+4. Set the GitHub secret `HOMEBREW_TAP_REPO` to the repository where the
+   homebrew tap will be deployed.  For example, we are using
+   [`shaka-project/homebrew-shaka-lab`](https://github.com/shaka-project/homebrew-shaka-lab).
 
 The `release.yaml` workflow will use the stored PAT to push to the homebrew tap
-repository at
-[shaka-project/homebrew-shaka-lab](https://github.com/shaka-project/homebrew-shaka-lab).
+repository.

--- a/distribution/macos/README.md
+++ b/distribution/macos/README.md
@@ -20,8 +20,9 @@ update notifications from Homebrew for their macOS packages.
    `repo` scope enabled.
 3. Copy the PAT into GitHub as a secret on this repository named
    `HOMEBREW_DEPLOY_TOKEN`.
-4. Set the GitHub secret `HOMEBREW_TAP_REPO` to the repository where the
-   homebrew tap will be deployed.  For example, we are using
+4. Create a GitHub repository secret named `HOMEBREW_TAP_REPO` with the name of
+   the repository where the homebrew tap will be deployed.  For example, we are
+   using
    [`shaka-project/homebrew-shaka-lab`](https://github.com/shaka-project/homebrew-shaka-lab).
 
 The `release.yaml` workflow will use the stored PAT to push to the homebrew tap

--- a/distribution/windows/README.md
+++ b/distribution/windows/README.md
@@ -15,6 +15,11 @@ update with `choco upgrade`.
 2. Create a service account key in Google Cloud.
 3. Copy the key in JSON format to GitHub as a repository secret named
    `APPENGINE_DEPLOY_KEY`.
+4. Create a GitHub repository secret named `APPENGINE_PROJECT_ID` with the App
+   Engine project ID to deploy to.
+5. Create a GitHub repository secret named `APPENGINE_PROJECT_VERSION` with the
+   App Engine project version to deploy to.
+
 
 The `release.yaml` workflow will use the stored key to deploy updates to App
 Engine, which will serve the packages.


### PR DESCRIPTION
This allows forks to configure their own homebrew TAP repos and App Engine deployments by configuring values in GitHub secrets.