### PR TITLE
docs: Link to distribution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,18 @@ Everything in this repo is licensed under [Apache license v2.0](LICENSE.txt).
  - [Shaka Lab Node](shaka-lab-node/README.md#readme): Selenium grid nodes
  - [Shaka Lab Gateway](shaka-lab-gateway/README.md#readme): Lab gateway (DHCP, DNS, AD, routing)
  - [Shaka Lab Gateway Client](shaka-lab-gateway-client/README.md#readme): Central lab user login
+
+
+## Distribution Systems
+
+Here you can find documentation for the various packge distribution systems
+used, and their setup on GitHub.  You can read these to understand how packages
+get distributed, or to help you debug issues with distribution.
+
+If you want to deploy packages from a fork, you will need to read these and
+follow the setup steps in each document.  Without those steps, the release
+workflow will not work.
+
+ - [Linux distribution](distribution/linux/README.md#readme)
+ - [Windows distribution](distribution/windows/README.md#readme)
+ - [macOS distribution](distribution/macos/README.md#readme)

--- a/distribution/linux/README.md
+++ b/distribution/linux/README.md
@@ -19,6 +19,8 @@ automatic updates to their Linux packages.
  - `gpg -o key --armor --export-secret-key nomail@shakalab.rocks`
 3. Copy the base64 `key` into GitHub as a repository secret named `DEB_GPG_KEY`
 4. Remove the exported secret key file with `rm key`
+5. Configure GitHub Pages for the repo by setting the deployment source to
+   "GitHub Actions".
 
 The `release.yaml` workflow will use the stored GPG key to sign packages, which
 will be distributed through GitHub Pages (`github.io`) on this repository.


### PR DESCRIPTION
This adds links from the main README to the distribution docs for each platform.  It also addds a missing detail in the Linux distribution setup.