### PR TITLE
fix: Fix Linux dependencies on old Ubuntu versions

### DIFF
--- a/shaka-lab-recommended-settings/linux/debian/control
+++ b/shaka-lab-recommended-settings/linux/debian/control
@@ -22,7 +22,7 @@ Build-Depends: debhelper (>= 9)
 Package: shaka-lab-recommended-settings
 Architecture: all
 Pre-Depends: shaka-lab-recommended-settings
-Depends: aptitude, arping, debconf-utils, dialog, net-tools, openssh-server, plocate, smartmontools, software-properties-common, tcpdump, vim
+Depends: aptitude, arping, debconf-utils, dialog, net-tools, openssh-server, plocate | mlocate, smartmontools, software-properties-common, tcpdump, vim
 Description: Shaka Lab Recommended Settings
  Depends on recommended packages and configures recommended settings for the
  Shaka Lab


### PR DESCRIPTION
Older versions of Ubuntu had mlocate instead of plocate.  Accept either as a dependency for shaka-lab-recommended-settings.