### PR TITLE
fix: Fix scripted update installation for Windows

### DIFF
--- a/shaka-lab-recommended-settings/windows/chocolateyinstall.ps1
+++ b/shaka-lab-recommended-settings/windows/chocolateyinstall.ps1
@@ -89,7 +89,7 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Nam
 echo "`nInstalling all Windows and driver updates now...`n"
 Install-PackageProvider -Name NuGet -Scope CurrentUser -Force | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process -Force
 Install-Module PSWindowsUpdate -Scope CurrentUser
 # NOTE: Needs admin rights
 Install-WindowsUpdate -Confirm:$false


### PR DESCRIPTION
PowerShell execution policies are a set of rules about what kinds of scripts can be executed.  Installing Windows updates in PowerShell uses an external module, and so we have to get the execution policy right to use it.

Policies can be set in several different scopes, and some scopes can override others if a policy is set at that level.

The default execution policy for regular users in home editions of Windows is "Restricted" at the scope of "CurrentUser", which is not permissive enough.  So we had been setting "CurrentUser" to "RemoteSigned", which allows remote scripts so long as they are properly signed.

If we're installing packages from an Admin shell, the default execution policy is "Bypass" at the scope of "Process" (the current shell).  This overrides the "CurrentUser"-"Restriced" policy, and is permissive enough.

However, if we are in Admin mode, with the "Process"-"Bypass" policy, the command to set "CurrentUser"-"RemoteSigned" would fail, because we are setting a policy that won't have any effect.  (It is overridden by the "Process"-"Bypass" policy.

The universal solution that works from both of these starting states is to set the "Process"-scoped policy to "RemoteSigned".  If we are in a normal user shell, this overrides the "CurrentUser" default.  If we are in an Admin shell, this replaces the "Process" default.  (The replacement in Admin mode is more restrictive than the default, but should be safer if the remote script doesn't pass a signature check.)