### PR TITLE
fix: Convert shaka-lab-node from Formula into Cask

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,26 +219,19 @@ jobs:
           # Wipe out the internal .git folder from the source repo.
           rm -rf shaka-lab-source/.git
 
-          # Recreate Formula and Casks folders.
-          mkdir -p Formula
+          # Recreate Cask folders.
           mkdir -p Casks
 
-          # Copy formulae and casks to their required locations in the tap repo.
-          cp shaka-lab-source/shaka-lab-node/macos/shaka-lab-node.rb \
-             Formula/
-          cp shaka-lab-source/shaka-lab-browsers/macos/shaka-lab-browsers.rb \
-             shaka-lab-source/shaka-lab-recommended-settings/macos/shaka-lab-recommended-settings.rb \
-             shaka-lab-source/shaka-lab-gateway-client/macos/shaka-lab-gateway-client.rb \
-             Casks/
+          # Copy all casks to their required locations in the tap repo.
+          cp shaka-lab-source/*/macos/*.rb Casks/
 
-          # Set the package version by editing the homebrew formulae and casks
-          for i in Formula/* Casks/*; do
+          # Set the package version by editing the homebrew casks
+          for i in Casks/*; do
             sed -e "s/^\(\s*version\s\+\"\).*\(\"\s*\)$/\1$PACKAGE_VERSION\2/" \
                 -i "$i"
           done
 
           # Update the tap repo with a new commit.
-          git add Formula/
           git add Casks/
           git add shaka-lab-source/
           git config user.email shaka-bot@users.noreply.github.com

--- a/shaka-lab-browsers/macos/README.md
+++ b/shaka-lab-browsers/macos/README.md
@@ -14,13 +14,13 @@ This is the macOS package.
 ```sh
 brew tap shaka-project/shaka-lab
 brew tap homebrew/cask-versions
-brew install --cask shaka-lab-browsers
+brew install shaka-lab-browsers
 ```
 
 ## Updates
 
 ```sh
-brew update && brew upgrade
+brew update && brew upgrade shaka-lab-browsers
 ```
 
 **NOTE**: This package does not control the update of any browsers.
@@ -31,7 +31,7 @@ if configured to do so.
 ## Uninstallation
 
 ```sh
-brew uninstall --cask shaka-lab-browsers
+brew uninstall shaka-lab-browsers
 brew autoremove
 ```
 

--- a/shaka-lab-gateway-client/macos/README.md
+++ b/shaka-lab-gateway-client/macos/README.md
@@ -21,13 +21,13 @@ to join the domain.
 
 ```sh
 brew tap shaka-project/shaka-lab
-brew install --cask shaka-lab-gateway-client
+brew install shaka-lab-gateway-client
 ```
 
 ## Updates
 
 ```sh
-brew update && brew upgrade
+brew update && brew upgrade shaka-lab-gateway-client
 ```
 
 ## Configuration
@@ -47,6 +47,6 @@ Directory Administrator password used to set up the Gateway.  This is necessary
 to leave the domain.
 
 ```sh
-brew uninstall --cask shaka-lab-gateway-client
+brew uninstall shaka-lab-gateway-client
 brew autoremove
 ```

--- a/shaka-lab-node/macos/README.md
+++ b/shaka-lab-node/macos/README.md
@@ -17,37 +17,36 @@ platforms, see [the general docs](../README.md#readme).
 ```sh
 brew tap shaka-project/shaka-lab
 brew install shaka-lab-node
-$(brew --prefix)/opt/shaka-lab-node/restart-services.sh
+/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Updates
 
 ```sh
-brew update && brew upgrade
-$(brew --prefix)/opt/shaka-lab-node/restart-services.sh
+brew update && brew upgrade shaka-lab-node
+/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Configuration
 
-The config file is at `/opt/homebrew/etc/shaka-lab-node-config.yaml` on Arm and
-`/usr/local/etc/shaka-lab-node-config.yaml` on Intel.
+The config file is at `/etc/shaka-lab-node-config.yaml`.
 See the [configuration section](../README.md#configuration) of the general doc.
 
 ## Restarting the service after editing the config
 
 ```sh
-$(brew --prefix)/opt/shaka-lab-node/restart-services.sh
+/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Tailing logs
 
 ```sh
-tail -f $(brew --prefix)/var/log/shaka-lab-node.err.log
+tail -f /opt/shaka-lab-node/logs/stderr.log
 ```
 
 ## Uninstallation
 
 ```sh
-$(brew --prefix)/opt/shaka-lab-node/stop-services.sh
+/opt/shaka-lab-node/stop-services.sh
 brew uninstall shaka-lab-node
 ```

--- a/shaka-lab-node/macos/restart-services.sh
+++ b/shaka-lab-node/macos/restart-services.sh
@@ -21,7 +21,7 @@ restart_service() {
   # Link the service into the user's LaunchAgent folder, so that it is
   # automatically loaded on login.
   mkdir -p ~/Library/LaunchAgents
-  ln -sf "$INSTALL_PATH/plists/$NAME.plist" ~/Library/LaunchAgents/
+  ln -sf "$INSTALL_PATH/$NAME.plist" ~/Library/LaunchAgents/
 
   # Load the service now if it's not loaded yet.
   local LIST="$(launchctl list | grep "$NAME")"
@@ -39,14 +39,3 @@ restart_service() {
 # Restart both services.
 restart_service shaka-lab-node-update
 restart_service shaka-lab-node-service
-
-# Configure log rotation.  10MB files (10240), compress with gzip (flag Z).
-# This needs to happen here.  It can't be done inside the Homebrew formula
-# because of sandboxing.  We must write files in a global location.
-if [ ! -f /etc/newsyslog.d/shaka-lab-node.conf ]; then
-  echo "Configuring service log rotation (using sudo)"
-  sudo tee /etc/newsyslog.d/shaka-lab-node.conf >/dev/null <<EOF
-# path                                        mode  count  size  when  flags pid_file
-$(brew --prefix)/var/log/shaka-lab-node.*.log 644   10     10240 *     Z     $(brew --prefix)/var/run/shaka-lab-node.pid
-EOF
-fi

--- a/shaka-lab-node/macos/shaka-lab-node-logrotate.conf
+++ b/shaka-lab-node/macos/shaka-lab-node-logrotate.conf
@@ -1,0 +1,4 @@
+# Configure log rotation for newsyslog.
+# 10MB files (10240), compress with gzip (flag Z).
+# path                          mode  count  size  when  flags pid_file
+/opt/shaka-lab-node/logs/*.log  644   10     10240 *     Z     /opt/shaka-lab-node/shaka-lab-node.pid

--- a/shaka-lab-node/macos/shaka-lab-node-service.plist
+++ b/shaka-lab-node/macos/shaka-lab-node-service.plist
@@ -26,17 +26,17 @@
     <array>
       <!-- The log wrapper works around issues with log rotation / launchd. -->
       <string>$HOMEBREW_PREFIX/bin/node</string>
-      <string>$HOMEBREW_PREFIX/opt/shaka-lab-node/log-wrapper.js</string>
-      <string>$HOMEBREW_PREFIX/var/log/shaka-lab-node.out.log</string>
-      <string>$HOMEBREW_PREFIX/var/log/shaka-lab-node.err.log</string>
-      <string>$HOMEBREW_PREFIX/var/run/shaka-lab-node.pid</string>
+      <string>/opt/shaka-lab-node/log-wrapper.js</string>
+      <string>/opt/shaka-lab-node/logs/stdout.log</string>
+      <string>/opt/shaka-lab-node/logs/stderr.log</string>
+      <string>/opt/shaka-lab-node/shaka-lab-node.pid</string>
       <!-- This is the service started by the wrapper. -->
       <string>$HOMEBREW_PREFIX/bin/node</string>
-      <string>$HOMEBREW_PREFIX/opt/shaka-lab-node/start-nodes.js</string>
+      <string>/opt/shaka-lab-node/start-nodes.js</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>$HOMEBREW_PREFIX/opt/shaka-lab-node</string>
+    <string>/opt/shaka-lab-node</string>
 
     <key>RunAtLoad</key>
     <true/>

--- a/shaka-lab-node/macos/shaka-lab-node-update.plist
+++ b/shaka-lab-node/macos/shaka-lab-node-update.plist
@@ -24,7 +24,7 @@
 
     <key>ProgramArguments</key>
     <array>
-      <string>$HOMEBREW_PREFIX/opt/shaka-lab-node/update-drivers.sh</string>
+      <string>/opt/shaka-lab-node/update-drivers.sh</string>
     </array>
 
     <key>RunAtLoad</key>

--- a/shaka-lab-node/macos/update-drivers.sh
+++ b/shaka-lab-node/macos/update-drivers.sh
@@ -20,11 +20,11 @@
 # Fail on error.
 set -e
 
-# Load Homebrew.
-eval "$(brew shellenv)"
+# Set PATH to include node, npm, and other homebrew executables.
+export PATH="$HOMEBREW_PREFIX/bin:$PATH"
 
 # Go to the install directory of shaka-lab-node.
-cd "$(brew --prefix shaka-lab-node)"
+cd /opt/shaka-lab-node
 
 # Update all modules.
 rm -f package-lock.json

--- a/shaka-lab-node/start-nodes.js
+++ b/shaka-lab-node/start-nodes.js
@@ -40,18 +40,9 @@ if (process.platform == 'win32') {
   exe = '.exe';
   cmd = '.cmd';
 } else if (process.platform == 'darwin') {
-  // Homebrew can be installed at an arbitrary location, and even the default
-  // varies by processor type.  (/opt/homebrew for Arm and /usr/local for
-  // Intel.)
-  const prefixProcess = child_process.spawnSync('brew', ['--prefix'], {
-    stdio: ['ignore', 'pipe', 'inherit'],
-    encoding: 'utf8',
-  });
-  const prefix = prefixProcess.stdout.trim();
-
-  configPath = `${prefix}/etc/shaka-lab-node-config.yaml`;
-  shakaLabNodePath = `${prefix}/opt/shaka-lab-node`;
-  workingDirectory = `${prefix}/opt/shaka-lab-node`;
+  configPath = '/etc/shaka-lab-node-config.yaml';
+  shakaLabNodePath = '/opt/shaka-lab-node';
+  workingDirectory = '/opt/shaka-lab-node';
   updateDrivers = `${shakaLabNodePath}/update-drivers.sh`;
 }
 

--- a/shaka-lab-recommended-settings/macos/README.md
+++ b/shaka-lab-recommended-settings/macos/README.md
@@ -18,19 +18,19 @@ This is the macOS package.
 
 ```sh
 brew tap shaka-project/shaka-lab
-brew install --cask shaka-lab-recommended-settings
+brew install shaka-lab-recommended-settings
 ```
 
 ## Updates
 
 ```sh
-brew update && brew upgrade
+brew update && brew upgrade shaka-lab-recommended-settings
 ```
 
 ## Uninstallation
 
 ```sh
-brew uninstall --cask shaka-lab-recommended-settings
+brew uninstall shaka-lab-recommended-settings
 brew autoremove
 ```
 


### PR DESCRIPTION
This simplifies the Java dependency and allows us to automatically restart services, since Cask installations are not sandboxed like Formulae.  The lack of sandboxing also allows us to simplify the installation paths somewhat.

Now all macOS packages are Homebrew Casks, not Formulae, which simplifies the deployment to use wildcards instead of explicit package lists.

Finally, I discovered that we don't need the --cask flag and that we can explicitly update individual packages instead of all-at-once, so I've udpated all the macOS package docs with these details.