### PR TITLE
fix: Misc macOS fixes

### DIFF
--- a/shaka-lab-browsers/macos/shaka-lab-browsers.rb
+++ b/shaka-lab-browsers/macos/shaka-lab-browsers.rb
@@ -32,6 +32,9 @@ cask "shaka-lab-browsers" do
   # We don't install anything.  We only depend on other casks.
   stage_only true
 
+  # Signal that this package does not need upgrading through "brew upgrade".
+  auto_updates true
+
   # Use preflight so that if the commands fail, the package is not considered
   # installed.
   preflight do
@@ -74,6 +77,16 @@ cask "shaka-lab-browsers" do
       puts "*** NOTE: Safari Technology Preview could not be installed. ***"
       puts "*** Safari TP install requires the latest version of macOS. ***"
     end
+  end
+
+  postflight do
+    # Take Firefox out of quarantine.  I'm not sure why this is only needed for
+    # Firefox and not Chrome or Edge.  Without this, the first time
+    # shaka-lab-node tries to start Firefox, a dialog box pops up from the OS
+    # and must be interacted with before tests can run for the first time.
+    system_command "/usr/bin/xattr", args: [
+      "-d", "com.apple.quarantine", "/Applications/Firefox.app",
+    ]
   end
 
   depends_on cask: "firefox"

--- a/shaka-lab-gateway-client/macos/shaka-lab-gateway-client.rb
+++ b/shaka-lab-gateway-client/macos/shaka-lab-gateway-client.rb
@@ -32,6 +32,9 @@ cask "shaka-lab-gateway-client" do
   # We don't install anything.  We only invoke OS tools to configure AD login.
   stage_only true
 
+  # Signal that this package does not need upgrading through "brew upgrade".
+  auto_updates true
+
   # Use preflight so that if the commands fail, the package is not considered
   # installed.
   preflight do

--- a/shaka-lab-recommended-settings/macos/shaka-lab-recommended-settings.rb
+++ b/shaka-lab-recommended-settings/macos/shaka-lab-recommended-settings.rb
@@ -33,6 +33,9 @@ cask "shaka-lab-recommended-settings" do
   # settings.
   stage_only true
 
+  # Signal that this package does not need upgrading through "brew upgrade".
+  auto_updates true
+
   # Use preflight so that if the commands fail, the package is not considered
   # installed.
   preflight do
@@ -50,9 +53,9 @@ cask "shaka-lab-recommended-settings" do
     ], sudo: true
 
     # Enable SSH for all users, not just admins
-    system_command "/usr/sbin/dseditgroup", args: [
-      "-o", "delete", "-t", "group", "com.apple.access_ssh",
-    ], sudo: true
+    # (This fails if run twice, so ignore failures here.  system_command
+    # doesn't let us ignore failures, so use Kernel.system.)
+    Kernel.system "/usr/bin/sudo", "/usr/sbin/dseditgroup", "-o", "delete", "-t", "group", "com.apple.access_ssh", :out=>["/dev/null"], :err=>["/dev/null"]
 
     # Enable VNC
     system_command "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart", args: [


### PR DESCRIPTION
 - Do not upgrade recommended-settings, gateway-client, or browsers packages automatically.  This avoid unnecessary prompts and annoying changes since Cask upgrades are uninstall followed by install.  (This is particularly a problem for gateway-client, where an upgrade leaves, then rejoins the domain.)  These packages can still be explicitly updated by name if needed.
 - Fix recommended-settings failure if SSH has already been enabled for all users.
 - Fix Firefox quarantine on initial installation of browsers package.