### PR TITLE
fix: Fix macOS Selenium node WRT autologin

### DIFF
--- a/shaka-lab-node/macos/README.md
+++ b/shaka-lab-node/macos/README.md
@@ -6,7 +6,14 @@ This is the macOS package.
 For documentation on the package and configuration, or for links to other
 platforms, see [the general docs](../README.md#readme).
 
-**NOTE**: Browsers running in a macOS node **will** be visible.
+**NOTE**: Browsers running in a macOS node **will** be visible, and autologin
+is required.  ([shaka-lab-recommended-settings](../../shaka-lab-recommended-settings/README.md#readme)
+takes care of this for you.)  Browsers will run as the user that is logged in
+on the GUI at the time this package is installed, so that should be the
+autologin user.
+
+**NOTE**: The autologin GUI user and the user running `brew` do not have to be
+the same.
 
 ## Pre-requisites
 
@@ -17,14 +24,12 @@ platforms, see [the general docs](../README.md#readme).
 ```sh
 brew tap shaka-project/shaka-lab
 brew install shaka-lab-node
-/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Updates
 
 ```sh
 brew update && brew upgrade shaka-lab-node
-/opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Configuration
@@ -35,7 +40,7 @@ See the [configuration section](../README.md#configuration) of the general doc.
 ## Restarting the service after editing the config
 
 ```sh
-/opt/shaka-lab-node/restart-services.sh
+sudo /opt/shaka-lab-node/restart-services.sh
 ```
 
 ## Tailing logs
@@ -47,6 +52,6 @@ tail -f /opt/shaka-lab-node/logs/stderr.log
 ## Uninstallation
 
 ```sh
-/opt/shaka-lab-node/stop-services.sh
+sudo /opt/shaka-lab-node/stop-services.sh
 brew uninstall shaka-lab-node
 ```

--- a/shaka-lab-node/macos/restart-services.sh
+++ b/shaka-lab-node/macos/restart-services.sh
@@ -13,28 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-INSTALL_PATH="$(dirname "$0")"
+INSTALL_PATH="/opt/shaka-lab-node"
+
+# Run this script as root if you're not already.
+if [[ "$EUID" != "0" ]]; then
+  exec sudo "$0"
+fi
 
 restart_service() {
   local NAME="$1"
 
+  # Get the user currently logged in on the GUI.
+  local GUI_USER=$(stat -f "%Su" /dev/console)
+  local GUI_HOME=$(eval "echo ~$GUI_USER")
+
+  # Fail on error
+  set -e
+
   # Link the service into the user's LaunchAgent folder, so that it is
   # automatically loaded on login.
-  mkdir -p ~/Library/LaunchAgents
-  ln -sf "$INSTALL_PATH/$NAME.plist" ~/Library/LaunchAgents/
+  mkdir -p $GUI_HOME/Library/LaunchAgents
+  ln -sf "$INSTALL_PATH/$NAME.plist" $GUI_HOME/Library/LaunchAgents/
+
+  # User-linked service definitions must be owned by that user.
+  # The underlying file,
+  chown $GUI_USER /Library/LaunchDaemons/"$NAME.plist"
+  # and the link itself.
+  chown -h $GUI_USER /Library/LaunchDaemons/"$NAME.plist"
 
   # Load the service now if it's not loaded yet.
   local LIST="$(launchctl list | grep "$NAME")"
   if [ -z "$LIST" ]; then
-    echo "Loading $NAME"
-    launchctl load ~/Library/LaunchAgents/"$NAME.plist"
+    if sudo -u $GUI_USER launchctl load $GUI_HOME/Library/LaunchAgents/"$NAME.plist"; then
+      echo "Loaded $NAME"
+    else
+      # launchctl load doesn't print error messages, so add one of our own.
+      rv=$?
+      echo "Loading $NAME failed with rv $rv"
+      return $rv
+    fi
   fi
 
   # Stop and start the service.
   echo "Restarting $NAME"
-  launchctl stop "$NAME"
-  launchctl start "$NAME"
+  sudo -u $GUI_USER launchctl stop "$NAME"
+  sudo -u $GUI_USER launchctl start "$NAME"
 }
+
+# Fail on error
+set -e
 
 # Restart both services.
 restart_service shaka-lab-node-update

--- a/shaka-lab-node/macos/restart-services.sh
+++ b/shaka-lab-node/macos/restart-services.sh
@@ -37,12 +37,12 @@ restart_service() {
 
   # User-linked service definitions must be owned by that user.
   # The underlying file,
-  chown $GUI_USER /Library/LaunchDaemons/"$NAME.plist"
+  chown $GUI_USER $GUI_HOME/Library/LaunchAgents/"$NAME.plist"
   # and the link itself.
-  chown -h $GUI_USER /Library/LaunchDaemons/"$NAME.plist"
+  chown -h $GUI_USER $GUI_HOME/Library/LaunchAgents/"$NAME.plist"
 
   # Load the service now if it's not loaded yet.
-  local LIST="$(launchctl list | grep "$NAME")"
+  local LIST="$(sudo -u $GUI_USER launchctl list | grep "$NAME")"
   if [ -z "$LIST" ]; then
     if sudo -u $GUI_USER launchctl load $GUI_HOME/Library/LaunchAgents/"$NAME.plist"; then
       echo "Loaded $NAME"

--- a/shaka-lab-node/macos/stop-services.sh
+++ b/shaka-lab-node/macos/stop-services.sh
@@ -13,5 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-launchctl stop shaka-lab-node-update
-launchctl stop shaka-lab-node-service
+# Run this script as root if you're not already.
+if [[ "$EUID" != "0" ]]; then
+  exec sudo "$0"
+fi
+
+# Get the user currently logged in on the GUI.
+GUI_USER=$(stat -f "%Su" /dev/console)
+GUI_HOME=$(eval "echo ~$GUI_USER")
+
+# Stop and unload the services.
+sudo -u $GUI_USER launchctl unload $GUI_HOME/Library/LaunchAgents/shaka-lab-node-update.plist
+sudo -u $GUI_USER launchctl unload $GUI_HOME/Library/LaunchAgents/shaka-lab-node-service.plist
+
+# Unlink the service definitions.
+rm -f $GUI_HOME/Library/LaunchAgents/shaka-lab-node-update.plist
+rm -f $GUI_HOME/Library/LaunchAgents/shaka-lab-node-service.plist

--- a/shaka-lab-node/macos/update-drivers.sh
+++ b/shaka-lab-node/macos/update-drivers.sh
@@ -23,6 +23,9 @@ set -e
 # Set PATH to include node, npm, and other homebrew executables.
 export PATH="$HOMEBREW_PREFIX/bin:$PATH"
 
+# Force npm to write its cache here.
+export HOME="/opt/shaka-lab-node"
+
 # Go to the install directory of shaka-lab-node.
 cd /opt/shaka-lab-node
 

--- a/shaka-lab-recommended-settings/macos/README.md
+++ b/shaka-lab-recommended-settings/macos/README.md
@@ -64,3 +64,5 @@ Settings configured automatically by this package:
  - Misc:
    - Enable time sync with Apple servers
    - Allow unsigned binaries (necessary for shaka-lab-node and WebDriver)
+   - Enable autologin for the current user (necessary for shaka-lab-node to run
+     typical GUI browsers)


### PR DESCRIPTION
On macOS, headless mode fails to take screenshots, so a GUI session is required.  The best way to manage this is with a user set for autologin, and the node service running as this user.

To streamline this, shaka-lab-recommended-settings now configures the system for autologin for the user installing that package, and shaka-lab-node runs as the logged in GUI user.

Once installed, the shaka-lab-node service can now be managed by a user other than the GUI user.  This allows us to have a non-personal account for testing, but individual user accounts for each admin to manage the system via SSH.

This also:
 - Updates documentation that was missed when we transitioned from Homebrew Formula to Cask.  The Cask can restart services for you, so you don't need to do that yourself on install or upgrade.
 - Updates documentation to use sudo on service scripts (restart/stop), which allows us to perform these actions even if the admin account differs from the logged in GUI account used for testing.
 - Moves installation from a variable path (relative to Homebrew) to a fixed path (/opt/shaka-lab-node), since everything is managed through sudo now and the install path doesn't have to be directly writable by the admin doing upgrades or making changes.