### PR TITLE
fix: Avoid Firefox snap installation

### DIFF
--- a/shaka-lab-browsers/linux/debian/control
+++ b/shaka-lab-browsers/linux/debian/control
@@ -22,6 +22,12 @@ Build-Depends: debhelper (>= 9)
 Package: shaka-lab-browsers
 Architecture: all
 Pre-Depends: shaka-lab-recommended-settings
-Depends: adb, firefox, google-chrome-stable, microsoft-edge-stable, scrcpy
+# NOTE: Setting a minimum version for Firefox will forbid usage of the "snap"
+# package.  The snap version of Firefox will not work for our test
+# infrastructure, but it has a version number like "1.1" instead of a Firefox
+# release version like "116".  The settings in shaka-lab-recommended-settings
+# will allow installation of Firefox directly from Mozilla's PPA instead, so
+# this dependency should be satisfiable.
+Depends: adb, firefox (>= 100), google-chrome-stable, microsoft-edge-stable, scrcpy
 Description: Shaka Lab Browsers
  A meta-package to install all major browsers for the Shaka Lab

--- a/shaka-lab-recommended-settings/linux/README.md
+++ b/shaka-lab-recommended-settings/linux/README.md
@@ -48,3 +48,4 @@ Settings configured automatically by this package:
    - Enable port-forwarding
  - Disable prompting for service restarts, always restart affected services
  - Configure additional apt repositories to install major browsers
+ - Prefer Mozila PPA for Firefox over Ubuntu snap package

--- a/shaka-lab-recommended-settings/linux/debian/shaka-lab-recommended-settings.postinst
+++ b/shaka-lab-recommended-settings/linux/debian/shaka-lab-recommended-settings.postinst
@@ -43,6 +43,10 @@ Package: firefox*
 Pin: release o=LP-PPA-mozillateam
 Pin-Priority: 501
 EOF
+# Make sure that unattended upgrades pull from this alternate repo, as well.
+cat <<EOF >/etc/apt/apt.conf.d/51unattended-upgrades-firefox
+Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:\${distro_codename}";
+EOF
 
 # Install the package signing key from Microsoft Edge.
 curl -L https://packages.microsoft.com/keys/microsoft.asc \


### PR DESCRIPTION
An automated upgrade on one of our lab devices reverted Firefox to the "official" Ubuntu snap package, overriding our choice of the Mozilla PPA version.

This ensures that automatic upgrades can use the PPA version as well, and creates a versioned dependency in shaka-lab-browsers so that only the PPA version will be accepted there.

Affected machines will need to uninstall firefox and shaka-lab-browsers, then reinstall.