### PR TITLE
fix: Remove package lock before updating windows drivers

### DIFF
--- a/shaka-lab-node/windows/update-drivers.cmd
+++ b/shaka-lab-node/windows/update-drivers.cmd
@@ -31,6 +31,7 @@ cd /D "C:\ProgramData\shaka-lab-node"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Install the latest packages.
+del package-lock.json
 call npm install
 if %errorlevel% neq 0 exit /b %errorlevel%
 


### PR DESCRIPTION
This was already done for Linux and Mac, and ensures we always get the latest versions without getting locked in or having to hardcode those version numbers.