### PR TITLE
fix: Fix shaka-lab-node dependency updating

### DIFF
--- a/shaka-lab-node/linux/update-drivers.sh
+++ b/shaka-lab-node/linux/update-drivers.sh
@@ -34,9 +34,8 @@ export NVM_DIR=/opt/shaka-lab/nvm
 # Go to the install directory of shaka-lab-node.
 cd /opt/shaka-lab/shaka-lab-node
 
-# Update all modules.
-rm -f package-lock.json
-npm install
+# Update all modules to the latest version allowed by package.json.
+npm update
 
 # Update all WebDrivers.
 ./node_modules/.bin/webdriver-installer .

--- a/shaka-lab-node/macos/update-drivers.sh
+++ b/shaka-lab-node/macos/update-drivers.sh
@@ -29,9 +29,8 @@ export HOME="/opt/shaka-lab-node"
 # Go to the install directory of shaka-lab-node.
 cd /opt/shaka-lab-node
 
-# Update all modules.
-rm -f package-lock.json
-npm install
+# Update all modules to the latest version allowed by package.json.
+npm update
 
 # Update all WebDrivers.
 ./node_modules/.bin/webdriver-installer .

--- a/shaka-lab-node/windows/update-drivers.cmd
+++ b/shaka-lab-node/windows/update-drivers.cmd
@@ -30,9 +30,8 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 cd /D "C:\ProgramData\shaka-lab-node"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-:: Install the latest packages.
-del package-lock.json
-call npm install
+:: Update all modules to the latest version allowed by package.json.
+call npm update
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Update all drivers.


### PR DESCRIPTION
`npm update` will update all dependencies to the latest version allowed by package.json.  By contrast, `npm install` will only update dependencies that no longer meet the requirements in package.json.

For example, imagine you have version 1.1.6 of a dep, but 1.1.7 is available.  If the requirement is `^1` (any v1 release), `npm install` will do nothing, even if you destroy the package lock first.  Running `npm update` will instead upgrade to 1.1.7, even if you don't destroy the package lock.