### PR TITLE
fix(Windows): Fix hung drivers on Windows

### DIFF
--- a/shaka-lab-node/start-nodes.js
+++ b/shaka-lab-node/start-nodes.js
@@ -176,7 +176,18 @@ function main() {
   // Update WebDrivers on startup.
   // This has a side-effect of also installing other requirements, such as
   // js-yaml, which we don't load until we need it below.
-  child_process.spawnSync(updateDrivers, /* args= */ [], spawnOptions);
+  const updateProcess = child_process.spawnSync(
+      updateDrivers, /* args= */ [], spawnOptions);
+  if (updateProcess.status) {
+    throw new Error(
+        `Driver update failed with exit code ${updateProcess.status}`);
+  }
+  if (updateProcess.error) {
+    // Hopefully this error object has enough context without us needing to
+    // write a custom message or wrap the Error object in any way.  We haven't
+    // triggered this in the wild yet.
+    throw updateProcess.error;
+  }
 
   const yaml = require('js-yaml');
 

--- a/shaka-lab-node/windows/README.md
+++ b/shaka-lab-node/windows/README.md
@@ -39,8 +39,10 @@ net start shaka-lab-node
 
 ## Tailing logs
 
-```sh
-powershell -command "Get-Content c:/ProgramData/shaka-lab-node/logs/shaka-lab-node-svc.err.log -Wait"
+In powershell:
+
+```ps1
+Get-Content c:/ProgramData/shaka-lab-node/logs/shaka-lab-node-svc.err.log -Wait
 ```
 
 ## Uninstallation

--- a/shaka-lab-node/windows/update-drivers.cmd
+++ b/shaka-lab-node/windows/update-drivers.cmd
@@ -34,6 +34,13 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 call npm update
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+:: Sometimes, msedgedriver hangs and the old version must be killed to update it.
+:: Kill all the common drivers just in case.
+C:\Windows\System32\taskkill.exe /IM msedgedriver.exe /F 2>&1
+C:\Windows\System32\taskkill.exe /IM chromedriver.exe /F 2>&1
+C:\Windows\System32\taskkill.exe /IM chromedriver-android.exe /F 2>&1
+C:\Windows\System32\taskkill.exe /IM geckodriver.exe /F 2>&1
+
 :: Update all drivers.
 call node_modules/.bin/webdriver-installer.cmd .
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
These hung drivers, when they occur, prevent the executable files from being deleted or updated. We have to kill common drivers before attempting to update. With this, the system can recover after updating shaka-lab-node.

We also needed to add a check to the main service to fail when a driver update fails for any reason.