### PR TITLE
feat(shaka-lab-node): Add support for Chromecast redirect mode

### DIFF
--- a/shaka-lab-node/node-templates.md
+++ b/shaka-lab-node/node-templates.md
@@ -89,7 +89,9 @@ xboxone:
 Here, the template has parameters `hostname`, `username`, `password`, and
 `msbuild`.  The `?` in `?msbuild` indicates that it is an optional parameter.
 The property definitions passed to Selenium then reference those as variables,
-such as `$hostname`, `$username`, etc.
+such as `$hostname`, `$username`, etc.  An optional parameter can also have a
+default value.  For example, to have an optional parameter named `redirect`
+that defaults to `true`, you would specify `?redirect=true`.
 
 
 ## Built-in Variables

--- a/shaka-lab-node/node-templates.yaml
+++ b/shaka-lab-node/node-templates.yaml
@@ -60,6 +60,8 @@ chromecast:
     - version
     - ?receiver-app-id  # optional
     - ?idle-timeout-seconds  # optional
+    - ?connection-timeout-seconds  # optional
+    - ?redirect=true  # optional, default true
   defs:
     genericwebdriver.browser.name: chromecast
     genericwebdriver.backend.exe: node_modules/.bin/chromecast-webdriver-server$cmd
@@ -67,6 +69,7 @@ chromecast:
     genericwebdriver.backend.params.receiver-app-id: $receiver-app-id
     genericwebdriver.backend.params.idle-timeout-seconds: $idle-timeout-seconds
     genericwebdriver.backend.params.connection-timeout-seconds: $connection-timeout-seconds
+    genericwebdriver.backend.params.redirect: $redirect
   capabilities:
     browserName: chromecast
     version: $version

--- a/shaka-lab-node/package.json
+++ b/shaka-lab-node/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "chromecast-webdriver-server": "^1",
+    "chromecast-webdriver-server": "^2",
     "chromeos-webdriver-server": "^1",
     "generic-webdriver-server": "^1",
     "js-yaml": "^4",


### PR DESCRIPTION
Chromecast WebDriver Server v2 adds support for a redirect mode, where it does not rely on an iframe.  This has many advantages for Shaka Player testing.

This adds support for this mode in shaka-lab-node, and enables it by default in the Shaka lab.

To accomplish this for Chromecast, we add general support for optional parameters with default values in the node template.