### PR TITLE
ci: Update appengine runtime for Windows package deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,14 +159,14 @@ jobs:
               "start": "express-chocolatey-server *.nupkg"
             },
             "engines": {
-              "node": "16.x.x"
+              "node": "22.x.x"
             }
           }
           EOF
 
           # Create the app.yaml definition for App Engine.
           cat >app.yaml <<EOF
-          runtime: nodejs16
+          runtime: nodejs22
           handlers:
             - url: /.*
               secure: always


### PR DESCRIPTION
Node16 is no longer supported.  The latest is node22, supported until 2027.  See https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#nodejs