### PR TITLE
chore(shaka-lab-node): Update Tizen WebDriver Server

### DIFF
--- a/shaka-lab-node/package.json
+++ b/shaka-lab-node/package.json
@@ -5,7 +5,7 @@
     "chromeos-webdriver-server": "^1",
     "generic-webdriver-server": "^1",
     "js-yaml": "^4",
-    "tizen-webdriver-server": "^1",
+    "tizen-webdriver-server": "^2",
     "webdriver-installer": "^1",
     "xbox-one-webdriver-server": "^1"
   }


### PR DESCRIPTION
Tizen WebDriver Server v2 was just released, with a migration to a new container registry.  This updates shaka-lab-node to point to this new release instead of the older, deprecated v1 releases.