### PR TITLE
fix(shaka-lab-github-runner): Fix service restart logic

### DIFF
--- a/shaka-lab-github-runner/linux/shaka-lab-github-runner@.service
+++ b/shaka-lab-github-runner/linux/shaka-lab-github-runner@.service
@@ -5,6 +5,14 @@ Requires=docker.service
 PartOf=shaka-lab-github-runners.target
 
 [Service]
+# Wait this long for the service to start up (0 disables timeouts)
 TimeoutStartSec=0
+# Always restart (meaning under all exit conditions, still limited in number
+# by StartLimit* options)
 Restart=always
+# Wait this long before restarting
+RestartSec=30s
+# This removes any limit on the number of retries
+StartLimitInterval=0
+# What to start
 ExecStart=/opt/shaka-lab/shaka-lab-github-runner/start-runner.sh %i


### PR DESCRIPTION
We should always try to restart these runners, but the systemd config for that was unclear.  This fixes the service logic to never give up on restarting the service.

We had a transient error in authentication to GitHub that took down 15/16 runner services.  Once they reached their start limit, they stopped completely in a failed state.

With this configuration, that would not have happened.  Eventually, they all would have come back up.