### PR TITLE
fix(shaka-lab-node): Fix startup on Windows

### DIFF
--- a/shaka-lab-node/start-nodes.js
+++ b/shaka-lab-node/start-nodes.js
@@ -196,8 +196,13 @@ function main() {
   // Update WebDrivers on startup.
   // This has a side-effect of also installing other requirements, such as
   // js-yaml, which we don't load until we need it below.
+  const updateSpawnOptions = Object.assign({}, spawnOptions);
+  if (process.platform == 'win32') {
+    // To run the .cmd script in the latest nodejs, you must pass shell=true.
+    updateSpawnOptions.shell = true;
+  }
   const updateProcess = child_process.spawnSync(
-      updateDrivers, /* args= */ [], spawnOptions);
+      updateDrivers, /* args= */ [], updateSpawnOptions);
   if (updateProcess.status) {
     throw new Error(
         `Driver update failed with exit code ${updateProcess.status}`);


### PR DESCRIPTION
A recent batch of updates changed the ability of nodejs to run a .cmd script directly.  This fixes it with an option to spawnSync.