### PR TITLE
Revert "chore(deps): Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download packages
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: windows-packages
 


### PR DESCRIPTION
Reverts shaka-project/shaka-lab#60, which broke artifact downloads.

I should have noticed that the robot PR was a major number bump and therefore might be a breaking change.