### PR TITLE
feat(shaka-lab-github-runner): Add support for nested containers

### DIFF
--- a/shaka-lab-github-runner/README.md
+++ b/shaka-lab-github-runner/README.md
@@ -119,6 +119,13 @@ them in text files inside `/etc/shaka-lab-github-runner.args.d/`.
 To add Docker command line arguments that apply to specific runner instances,
 add them in text files inside `/etc/shaka-lab-github-runner@$INSTANCE.args.d/`.
 
+To support nested containers, put this in
+`/etc/shaka-lab-github-runner.args.d/docker-nested`:
+
+```
+-v /var/run/docker.sock:/var/run/docker.sock
+```
+
 ## Updates
 
 ```sh


### PR DESCRIPTION
If you want to run workflows with jobs that inside containers, you need support for nested containers.  This is now possible with a little bit of configuration.

To make this work, we need to synchronize a few important folders between the host and the main container so that they can be forwarded on correctly to nested containers.

Part of the solution to https://github.com/shaka-project/static-ffmpeg-binaries/issues/28