### PR TITLE
fix(shaka-lab-node): Fix Windows path to PowerShell

### DIFF
--- a/shaka-lab-node/windows/update-drivers.cmd
+++ b/shaka-lab-node/windows/update-drivers.cmd
@@ -42,5 +42,6 @@ C:\Windows\System32\taskkill.exe /IM chromedriver-android.exe /F 2>&1
 C:\Windows\System32\taskkill.exe /IM geckodriver.exe /F 2>&1
 
 :: Update all drivers.
+SET PATH=%PATH%;C:\Windows\System32\WindowsPowerShell\v1.0
 call node_modules/.bin/webdriver-installer.cmd .
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
After some upgrades, the path to PowerShell is no longer in the default PATH environment variable.  This makes it explicit in the script that updates drivers.

If the actual path to PowerShell on your system differs from the norm, set your global PATH environment variable appropriately.