### PR TITLE
fix(shaka-lab-github-runner): Make nested container support configurable

### DIFF
--- a/shaka-lab-github-runner/README.md
+++ b/shaka-lab-github-runner/README.md
@@ -55,12 +55,15 @@ echo deb https://shaka-project.github.io/shaka-lab/ stable main | \
 sudo apt update
 
 # Configure your GitHub details before installation to avoid prompting.
+# Note that support_nested_containers is incompatible with number_of_runners
+# greater than 1.
 cat << EOF | sudo debconf-set-selections
 shaka-lab-github-runner shaka-lab-github-runner/scope select SCOPE
 shaka-lab-github-runner shaka-lab-github-runner/scope_name string SCOPE_NAME
 shaka-lab-github-runner shaka-lab-github-runner/access_token password ACCESS_TOKEN
 shaka-lab-github-runner shaka-lab-github-runner/labels string LABELS
 shaka-lab-github-runner shaka-lab-github-runner/number_of_runners string NUMBER
+shaka-lab-github-runner shaka-lab-github-runner/support_nested_containers boolean TRUE_OR_FALSE
 EOF
 
 # Install the package, which will not have to prompt for anything thanks to
@@ -119,12 +122,6 @@ them in text files inside `/etc/shaka-lab-github-runner.args.d/`.
 To add Docker command line arguments that apply to specific runner instances,
 add them in text files inside `/etc/shaka-lab-github-runner@$INSTANCE.args.d/`.
 
-To support nested containers, put this in
-`/etc/shaka-lab-github-runner.args.d/docker-nested`:
-
-```
--v /var/run/docker.sock:/var/run/docker.sock
-```
 
 ## Updates
 

--- a/shaka-lab-github-runner/linux/debian/shaka-lab-github-runner.postinst
+++ b/shaka-lab-github-runner/linux/debian/shaka-lab-github-runner.postinst
@@ -74,6 +74,7 @@ db_go
 db_input high shaka-lab-github-runner/access_token || true
 db_input high shaka-lab-github-runner/labels || true
 db_input high shaka-lab-github-runner/number_of_runners || true
+db_input high shaka-lab-github-runner/support_nested_containers || true
 db_go
 
 # Now we should have all necessary configuration.
@@ -87,6 +88,8 @@ db_get shaka-lab-github-runner/labels
 LABELS="$RET"
 db_get shaka-lab-github-runner/number_of_runners
 NUMBER_OF_RUNNERS="$RET"
+db_get shaka-lab-github-runner/support_nested_containers
+SUPPORT_NESTED_CONTAINERS="$RET"
 
 
 ### INSTALLATION ###

--- a/shaka-lab-github-runner/linux/debian/templates
+++ b/shaka-lab-github-runner/linux/debian/templates
@@ -35,3 +35,9 @@ Template: shaka-lab-github-runner/number_of_runners
 Type: string
 Description: Number of runner instances
  The number of runner instances to launch in parallel.
+
+Template: shaka-lab-github-runner/support_nested_containers
+Type: boolean
+Description: Support nested containers?
+ If true, support nested containers.  Incompatible with multiple runner
+ instances on the same host.


### PR DESCRIPTION
Running nested container setup on a host with multiple runner instances causes them to conflict with each other, because they each try to control certain locations on the host.  By making nested container support configurable, we can avoid it on hosts with multiple instances.