### PR TITLE
ci: Fix macOS deployment workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,9 +198,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: '${{ secrets.HOMEBREW_TAP_REPO }}'
-          fetch-depth: 0  # The entire repo history, so we can push an update
-          # To push to this repo, an explicit token is used to authenticate.
-          persist-credentials: false
+          # Get the entire repo history, so we can push an update.
+          fetch-depth: 0
+          # To push to the tap repo, an explicit token is used to authenticate,
+          # and we persist it for the later step where we push.  Nothing is
+          # executed in this job.  Files are copied and staged only.
+          token: '${{ secrets.HOMEBREW_DEPLOY_TOKEN }}'
+          persist-credentials: true
 
       - name: Wipe source and formula folders
         run: |
@@ -245,9 +249,4 @@ jobs:
           git commit -m "Release $PACKAGE_VERSION"
 
       - name: Push homebrew repo
-        run: |
-          # Remove default authentication headers from GitHub Actions
-          # environment, since we're pushing to a different repo as a different
-          # user.
-          git config --unset-all http.https://github.com/.extraheader
-          git push https://shaka-bot:${{ secrets.HOMEBREW_DEPLOY_TOKEN }}@github.com/${{ secrets.HOMEBREW_TAP_REPO }}
+        run: git push


### PR DESCRIPTION
I'm not sure why/when this stopped working, but probably it was a side-effect of another change, like the default token permissions, or setting `persist-credentials: false`.  This fixes it.