### PR TITLE
ci: Update deprecated workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
           gpg -o staging/public.key --armor --export nomail@shakalab.rocks
 
       - name: Upload packages
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: staging
 


### PR DESCRIPTION
The underlying upload-artifact action @v1-@v3 will stop working at the end of the month.  actions/upload-pages-artifact@v3 uses actions/upload-artifact@v4.