### PR TITLE
feat(shaka-lab-node): Add daily restart scheduled by UTC time

### DIFF
--- a/shaka-lab-node/linux/shaka-lab-node.service
+++ b/shaka-lab-node/linux/shaka-lab-node.service
@@ -24,6 +24,7 @@ Type=simple
 User=shaka-lab-node
 ExecStart=/opt/shaka-lab/shaka-lab-node/start-nodes.sh
 Restart=always
+SuccessExitStatus=2
 
 [Install]
 WantedBy=multi-user.target

--- a/shaka-lab-node/macos/log-wrapper.js
+++ b/shaka-lab-node/macos/log-wrapper.js
@@ -105,36 +105,73 @@ function main() {
     process.exit(1);
   }
 
-  const child = child_process.spawn(command, commandArgs, {
-    // Ignore stdin, but capture stdout and stderr as pipes.
-    stdio: ['ignore', 'pipe', 'pipe'],
-    // Make sure children are attached to the parent.
-    detached: false,
-  });
+  let child = null;
+  let quitting = false;
 
-  child.once('error', (error) => {
-    console.log('Failed to spawn child process!');
-    console.log(error);
-  });
-  child.once('spawn', () => {
-    console.log('Child process started:', [command].concat(commandArgs));
-  });
+  const spawnChild = () => {
+    if (quitting) {
+      return;
+    }
 
-  child.stdout.on('data', (chunk) => writeToLog(stdoutLogFd, chunk));
-  child.stderr.on('data', (chunk) => writeToLog(stderrLogFd, chunk));
-  child.stdout.resume();
-  child.stderr.resume();
+    child = child_process.spawn(command, commandArgs, {
+      // Ignore stdin, but capture stdout and stderr as pipes.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Make sure children are attached to the parent.
+      detached: false,
+    });
+
+    child.once('error', (error) => {
+      console.log('Failed to spawn child process!');
+      console.log(error);
+    });
+    child.once('spawn', () => {
+      console.log('Child process started:', [command].concat(commandArgs));
+    });
+
+    child.stdout.on('data', (chunk) => writeToLog(stdoutLogFd, chunk));
+    child.stderr.on('data', (chunk) => writeToLog(stderrLogFd, chunk));
+    child.stdout.resume();
+    child.stderr.resume();
+
+    child.once('exit', (code, signal) => {
+      console.log(`Child process exited with code ${code}, signal ${signal}.`);
+      child = null;
+      if (!quitting) {
+        console.log('Restarting child in 5s...');
+        setTimeout(spawnChild, 5000);
+      }
+    });
+  };
+
+  spawnChild();
 
   process.on('SIGHUP', () => {
     console.log('Received SIGHUP, reopening log files.');
     reopenLogs();
   });
 
+  // Handle termination signals to quit gracefully.
+  const quit = () => {
+    console.log('Quitting log-wrapper.');
+    quitting = true;
+    if (child && child.exitCode == null) {
+      child.once('exit', () => process.exit(0));
+      child.kill();
+      // Fallback in case the child hangs.
+      setTimeout(() => process.exit(0), 1000);
+    } else {
+      process.exit(0);
+    }
+  };
+
+  process.once('SIGINT', quit);
+  process.once('SIGTERM', quit);
+
   // When _this_ process stops...
   process.once('exit', () => {
-    console.log('Exitting.');
+    console.log('Exiting.');
 
-    if (child.exitCode == null) {
+    if (child && child.exitCode == null) {
       // Still running.  Stop it.
       child.kill();
     }

--- a/shaka-lab-node/shaka-lab-node-config.md
+++ b/shaka-lab-node/shaka-lab-node-config.md
@@ -50,6 +50,21 @@ This field is optional, but may be necessary for systems with multiple IPs.
 Devices running Docker or using VPNs are very likely to have multiple IPs.
 
 
+## Daily Restart
+
+The nodes can be scheduled to restart daily to maintain stability.  You can
+specify a fixed UTC time for the restart:
+
+```yaml
+# Optional: Restart the nodes daily at 03:00 UTC.
+daily_restart: "03:00"
+```
+
+When the restart time is reached, the `shaka-lab-node` process will exit, and the
+OS's service manager will restart it.  If this field is omitted, the nodes will
+run indefinitely.
+
+
 ## Template Instantiation
 
 The details of Selenium configuration are kept in templates (see

--- a/shaka-lab-node/shaka-lab-node-config.yaml
+++ b/shaka-lab-node/shaka-lab-node-config.yaml
@@ -24,6 +24,10 @@ hub: http://127.0.0.1:4444/
 # properly registered.
 #host: 192.168.1.55
 
+# Optional: Restart the nodes daily to maintain stability.
+# Specify a specific UTC time in "HH:MM" format.
+#daily_restart: "03:00"
+
 # The Selenium nodes to create.  Customize this to your lab devices.
 # Any regular browser you enable will have to be installed separately.
 nodes:

--- a/shaka-lab-node/start-nodes.js
+++ b/shaka-lab-node/start-nodes.js
@@ -148,6 +148,37 @@ function optionalParam(nodeConfig, paramName, defaultValue) {
 }
 
 /**
+ * Calculate the number of milliseconds until the next occurrence of a specific
+ * UTC time.
+ *
+ * @param {string} utcTimeStr A time in "HH:MM" format (UTC)
+ * @return {number}
+ */
+function getMsUntilNextOccurrence(utcTimeStr) {
+  const parts = utcTimeStr.split(':');
+  if (parts.length != 2) {
+    console.error(`Invalid daily_restart time format: "${utcTimeStr}". ` +
+                  'Expected "HH:MM".');
+    process.exit(1);
+  }
+  const hours = parseInt(parts[0], 10);
+  const minutes = parseInt(parts[1], 10);
+  if (isNaN(hours) || isNaN(minutes) ||
+      hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    console.error(`Invalid daily_restart time: "${utcTimeStr}".`);
+    process.exit(1);
+  }
+
+  const now = new Date();
+  const next = new Date(now);
+  next.setUTCHours(hours, minutes, 0, 0);
+  if (next <= now) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next.getTime() - now.getTime();
+}
+
+/**
  * Substitute parameters (such as "$exe") into a config's string value.
  *
  * @param {string} string
@@ -313,6 +344,18 @@ function main() {
     args.push('-capabilities', capabilitiesArray.join(','));
 
     nodeCommands.push(args);
+  }
+
+  // Schedule a daily restart to maintain stability.
+  const dailyRestart = config['daily_restart'];
+
+  if (dailyRestart && typeof dailyRestart == 'string') {
+    const msUntilRestart = getMsUntilNextOccurrence(dailyRestart);
+    console.log(`Scheduling restart in ${msUntilRestart / 1000}s`);
+    setTimeout(() => {
+      console.log('Restart time reached. Exiting.');
+      process.exit(2);
+    }, msUntilRestart);
   }
 
   // Launch the node commands.  If any of them fail, shut down the others.

--- a/shaka-lab-node/windows/shaka-lab-node-svc.yml
+++ b/shaka-lab-node/windows/shaka-lab-node-svc.yml
@@ -15,6 +15,7 @@
 # Node service definition for the tool WinSW: https://github.com/winsw/winsw
 
 # NOTE that we are using WinSW v2, not v3, which uses XML configs only.
+# See https://github.com/winsw/winsw/blob/v2/doc/yamlConfigFile.md
 
 # NOTE also that the upstream documentation for winsw is mistaken.  They use
 # lowercase, but camelcase is required.
@@ -27,6 +28,12 @@ executable: C:\Program Files\nodejs\node.exe
 arguments: C:\ProgramData\chocolatey\lib\shaka-lab-node\start-nodes.js
 workingDirectory: C:\ProgramData\shaka-lab-node\
 stopParentProcessFirst: true  # Shut down by killing the parent process
+
+# Restart the service on failure (non-zero exit code).
+# This is required for the daily restart feature to work on Windows.
+onFailure:
+  - action: restart
+    delay: 10 sec
 
 env:
   # Since the main script and modules live in different places, we need an


### PR DESCRIPTION
This allows nodes to be restarted daily at a specific UTC time to improve stability and recover from intermittent Selenium issues. The feature is supported on Linux (via systemd), Windows (via WinSW), and macOS (via a new restart loop in log-wrapper.js).

- Use exit code 2 for all intentional restarts in start-nodes.js.
- Configure systemd on Linux to treat exit code 2 as success.
- Configure WinSW on Windows to restart on non-zero exit codes.
- Make macOS log-wrapper.js restart on any exit.