### PR TITLE
fix(shaka-lab-recommended-settings): Fix compat with Ubuntu 24.04+

### DIFF
--- a/shaka-lab-recommended-settings/linux/debian/shaka-lab-recommended-settings.postinst
+++ b/shaka-lab-recommended-settings/linux/debian/shaka-lab-recommended-settings.postinst
@@ -20,7 +20,13 @@
 set -e
 
 # Reload sshd after installing new sshd configs.
-systemctl reload-or-restart sshd
+if systemctl cat ssh &>/dev/null; then
+  # Since Ubuntu 24.04
+  systemctl reload-or-restart ssh
+else
+  # In Ubuntu 22.04 and earlier
+  systemctl reload-or-restart sshd
+fi
 
 # Configure additional apt repositories for third-party browser packages.
 # This makes it possible to then install the shaka-lab-browsers metapackage,


### PR DESCRIPTION
In Ubuntu 24.04 and newer, the OpenSSH systemd service is called "ssh", not "sshd".